### PR TITLE
Add option to pass HTTP headers for HTTP-based MCP servers

### DIFF
--- a/src/par_mcp_inspector_tui/models/server.py
+++ b/src/par_mcp_inspector_tui/models/server.py
@@ -51,6 +51,7 @@ class MCPServer(BaseModel):
     host: str | None = None  # For TCP transport
     port: int | None = None  # For TCP transport
     url: str | None = None  # For HTTP transport
+    headers: dict[str, str] | None = None  # Custom HTTP headers for HTTP transport
     env: dict[str, str] | None = None
     roots: list[str] | None = None  # Filesystem roots for the server
     toast_notifications: bool = True  # Show toast notifications for server notifications
@@ -75,6 +76,7 @@ class MCPServer(BaseModel):
         elif self.transport == TransportType.HTTP:
             return {
                 "url": self.url,
+                "headers": self.headers or {},
             }
         else:
             raise ValueError(f"Unknown transport type: {self.transport}")

--- a/src/par_mcp_inspector_tui/models/tool.py
+++ b/src/par_mcp_inspector_tui/models/tool.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 class ToolParameterProperties(BaseModel):
     """Properties for a tool parameter."""
 
-    type: str
+    type: str | None = None
     description: str | None = None
     enum: list[Any] | None = None
     items: dict[str, Any] | None = None

--- a/src/par_mcp_inspector_tui/services/mcp_service.py
+++ b/src/par_mcp_inspector_tui/services/mcp_service.py
@@ -200,9 +200,10 @@ class MCPService:
                         port=server.port or 3333,
                     )
                 elif server.transport == TransportType.HTTP:
-                    self._client = HttpMCPClient(debug=self._debug, roots=server_roots)
+                    self._client = HttpMCPClient(debug=self._debug, roots=server_roots, headers=server.headers)
                     await self._client.connect(
                         url=server.url or "",
+                        headers=server.headers,
                     )
                 else:
                     raise MCPClientError(f"Unsupported transport: {server.transport}")


### PR DESCRIPTION
Having custom HTTP headers is quite useful for HTTP-based MCP servers. This PR adds that.